### PR TITLE
Fix for Windows

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,8 @@
 #
 import os
 import sys
-# sys.path.insert(0, os.path.abspath('.'))
-# sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 # -- General configuration ------------------------------------------------
 # import sphinx


### PR DESCRIPTION
@arcondello : this fix helps for Windows.

```(env) C:\Users\jpasvolsky\!git_DocsOS\env\ADTT\dwave-neal\docs>..\..\..\make html
Running Sphinx v1.7.2

Configuration error:
There is a programable error in your configuration file:

Traceback (most recent call last):
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\sphinx\config.py", line 161, in __init__
    execfile_(filename, config)
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\sphinx\util\pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\six.py", line 709, in exec_
    exec("""exec _code_ in _globs_, _locs_""")
  File "<string>", line 1, in <module>
  File "conf.py", line 65, in <module>
    from neal.package_info import __version__
ImportError: No module named neal.package_info```