### PR TITLE
Set proper env variables for windows python3.4 build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,6 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
-      MSSdk: 1
-      DISTUTILS_USE_SDK: 1
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
@@ -25,6 +23,9 @@ environment:
 install:
   - "%PYTHON%\\python.exe --version"
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+
+  # for python34-x64
+  - echo "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 > "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\bin\amd64/vcvars64.bat"
 
 build_script:
   - "%PYTHON%\\python.exe setup.py build_ext --inplace"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,8 @@ environment:
     - PYTHON: "C:\\Python27-x64"
     - PYTHON: "C:\\Python34"
     - PYTHON: "C:\\Python34-x64"
+      MSSdk: 1
+      DISTUTILS_USE_SDK: 1
     - PYTHON: "C:\\Python35"
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"


### PR DESCRIPTION
Windows 64bit builds with python3.4 are failing on appveyor