### PR TITLE
Support SampleSet for `initial_states`

### DIFF
--- a/neal/sampler.py
+++ b/neal/sampler.py
@@ -154,9 +154,8 @@ class SimulatedAnnealingSampler(dimod.Sampler):
                 * [deprecated] tuple, where the first value is a numpy array of
                   initial states to seed the simulated annealing runs, and the
                   second is a dict defining a linear variable labelling.
-
-                Initial states provided are assumed to use the same vartype the
-                BQM is using.
+                  In tuple format, initial states provided are assumed to use
+                  the same vartype the BQM is using.
 
                 If initial states are not provided (set to ``None``), uniform
                 random samples are use. If they are provided, the number of

--- a/neal/sampler.py
+++ b/neal/sampler.py
@@ -20,6 +20,7 @@ A dimod sampler_ that uses the simulated annealing algorithm.
 from __future__ import division
 
 import math
+import warnings
 
 from numbers import Integral
 from random import randint
@@ -150,7 +151,7 @@ class SimulatedAnnealingSampler(dimod.Sampler):
                 Initial states provided either as:
 
                 * :class:`dimod.SampleSet`, or
-                * tuple, where the first value is a numpy array of
+                * [deprecated] tuple, where the first value is a numpy array of
                   initial states to seed the simulated annealing runs, and the
                   second is a dict defining a linear variable labelling.
 
@@ -269,6 +270,8 @@ class SimulatedAnnealingSampler(dimod.Sampler):
                 variables = initial_states.variables
                 init_label_map = dict(zip(variables, range(len(variables))))
             else:
+                warnings.warn("tuple format for 'initial_states' is deprecated "
+                              "in favor of 'dimod.SampleSet'.", DeprecationWarning)
                 initial_states_array, init_label_map = initial_states
 
             if not initial_states_array.shape == states_shape:

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -242,6 +242,15 @@ class TestSimulatedAnnealingSampler(unittest.TestCase):
         self.assertTrue(np.array_equal(response.record.sample, expected_response.record.sample))
         self.assertTrue(np.array_equal(response.record.energy, expected_response.record.energy))
 
+    def test_sampleset_initial_states(self):
+        bqm = dimod.BQM.from_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})
+        initial_states = dimod.SampleSet.from_samples_bqm({'a': 1, 'b': -1, 'c': 1}, bqm)
+
+        response = Neal().sample(bqm, initial_states=initial_states, num_reads=1)
+
+        self.assertEqual(len(response), 1)
+        self.assertEqual(response.first.energy, -1)
+
 
 class TestDefaultIsingBetaRange(unittest.TestCase):
     def test_empty_problem(self):


### PR DESCRIPTION
Deprecate the old tuple format.

Close #53.