### PR TITLE
Added "answer_mode"

### DIFF
--- a/neal/sampler.py
+++ b/neal/sampler.py
@@ -357,33 +357,32 @@ class SimulatedAnnealingSampler(dimod.Sampler):
             seed, numpy_initial_states, interrupt_function)
 
         # change the format according to answer_mode
-        if 'answer_mode' in kwargs:
-            if kwargs['answer_mode'] == 'raw':
-                num_occurrences = np.ones(len(samples))
-            elif kwargs['answer_mode'] == 'histogram':
-                sort_index = np.argsort(energies)
-                samples_sorted = samples[sort_index]
-                energies_sorted = energies[sort_index]
+        if answer_mode == 'histogram':
+            sort_index = np.argsort(energies)
+            samples_sorted = samples[sort_index]
+            energies_sorted = energies[sort_index]
 
-                samples = np.empty((0, samples.shape[1]), int)
-                energies = np.empty((0), int)
-                num_occurrences = np.empty((0), int)
+            samples = np.empty((0, samples.shape[1]), int)
+            energies = np.empty((0), int)
+            num_occurrences = np.empty((0), int)
 
-                count_duplications = 1
-                for i in range(1, len(samples_sorted)):
-                    if (energies_sorted[i - 1] == energies_sorted[i]) \
-                            and (samples_sorted[i - 1].all() == samples_sorted[i].all()):
-                        count_duplications += 1
-                    else:
-                        samples = np.append(samples, samples_sorted[[i - 1]], axis=0)
-                        energies = np.append(energies, energies_sorted[i - 1])
-                        num_occurrences = np.append(num_occurrences, count_duplications)
-                        count_duplications = 1
-                samples = np.append(samples, samples_sorted[[len(samples_sorted) - 1]], axis=0)
-                energies = np.append(energies, energies_sorted[len(energies_sorted) - 1])
-                num_occurrences = np.append(num_occurrences, count_duplications)
-        else:
+            count_duplications = 1
+            for i in range(1, len(samples_sorted)):
+                if (energies_sorted[i - 1] == energies_sorted[i]) \
+                        and (samples_sorted[i - 1].all() == samples_sorted[i].all()):
+                    count_duplications += 1
+                else:
+                    samples = np.append(samples, samples_sorted[[i - 1]], axis=0)
+                    energies = np.append(energies, energies_sorted[i - 1])
+                    num_occurrences = np.append(num_occurrences, count_duplications)
+                    count_duplications = 1
+            samples = np.append(samples, samples_sorted[[len(samples_sorted) - 1]], axis=0)
+            energies = np.append(energies, energies_sorted[len(energies_sorted) - 1])
+            num_occurrences = np.append(num_occurrences, count_duplications)
+        elif answer_mode == 'raw':
             num_occurrences = np.ones(len(samples))
+        else:
+            raise ValueError("'answer_mode' should be a 'histogram' or 'raw'")
         off = _bqm.spin.offset
         info = {
             "beta_range": beta_range,

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -88,7 +88,8 @@ class TestSimulatedAnnealingSampler(unittest.TestCase):
         sampler = Neal()
         h = {'a': 0, 'b': -1, 'c': 2}
         J = {('a', 'b'): -1, ('b', 'c'): 2, ('a', 'c'): 4}
-        response1 = sampler.sample_ising(h, J, answer_mode='histogram', num_reads=1)
+        response1 = sampler.sample_ising(h, J, answer_mode='histogram', num_reads=10)
+        print(response1)
         response2 = sampler.sample_ising(h, J, answer_mode='raw', num_reads=1)
         self.assertEqual(response1, response2)
 
@@ -111,9 +112,10 @@ class TestSimulatedAnnealingSampler(unittest.TestCase):
         count_dict1 = collections.defaultdict(int)
         count_dict2 = collections.defaultdict(int)
         for sample, energy, num_occurrences in response1.data():
-            count_dict1[tuple(sample.values())] += num_occurrences
+            count_dict1[tuple(sample.values())] = num_occurrences
         for sample, energy, num_occurrences in response2.data():
             count_dict2[tuple(sample.values())] += num_occurrences
+        self.assertDictEqual(count_dict1, count_dict2)
 
     def test_num_reads(self):
         sampler = Neal()


### PR DESCRIPTION
Report and pull request

**Description**
SimulatedAnnealingSampler.sample responses the dimod.SampleSet object.
In samplers such as EmbeddingComposites, answer_mode is set 'histogram' as its default value.
https://docs.dwavesys.com/docs/latest/c_solver_1.html#answer-format
However, in this repository, sampler doesn't return answers following histogram format even if we set answer_mode='histogram'.
I modified this and added some tests.
(If you consider this implementation bad, please ignore or edit.)

**To Reproduce**
```python
import neal
sampler = neal.SimulatedAnnealingSampler()
h = {0:1, 1:2}
J = {(0,1):1}
sampler.sample_ising(h, J)
sampler.sample_ising(h, J, answer_mode='histogram', num_reads=3)
```
This outputs
```text
SampleSet(rec.array([([-1, -1], -2., 1), ([ 1, -1], -2., 1), ([-1, -1], -2., 1)],
          dtype=[('sample', 'i1', (2,)), ('energy', '<f8'), ('num_occurrences', '<i8')]), [0, 1], {'beta_range': [0.23104906018664842, 4.605170185988092], 'beta_schedule_type': 'geometric'}, 'SPIN')
```

**Expected behavior**
```text
SampleSet(rec.array([([ 1, -1], -2., 3)],
          dtype=[('sample', '<i8', (2,)), ('energy', '<f8'), ('num_occurrences', '<i8')]), [0, 1], {'beta_range': [0.23104906018664842, 4.605170185988092], 'beta_schedule_type': 'geometric'}, 'SPIN')
```

**Environment:**
 - OS: macOS Mojave 10.14.6
 - Python version: 3.7.0

**Additional context**
I set default value of answer_mode 'raw'.
This is because to avoid unexpected behavior in surrounding repositories related to this.
If it is OK, please change this.