### PR TITLE
Force (lie about) macOS 10.9 binary compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1-macos-10.9
 
       - run:
           name: install python
@@ -148,7 +148,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1-macos-10.9
 
       - run:
           name: create virtualenv
@@ -303,7 +303,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
+            - pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1-macos-10.9
 
       - run:
           name: install python
@@ -313,7 +313,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.pyenv
-          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1
+          key: pyenv-{{ .Environment.CIRCLE_JOB }}-xcode-11.2.1-macos-10.9
 
       - run:
           name: create virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,14 +74,14 @@ jobs:
       - store_artifacts:
           path: ./dist
 
-      - run: &sdist-install-template
+      - run:
           name: test installing from sdist without cython
           command: |
             python -m virtualenv env_sdist
             . env_sdist/bin/activate
             pip install dist/dwave-neal-*.tar.gz
 
-      - run: &sdist-cython-install-template
+      - run:
           name: install sdist with cython
           command: |
             python -m virtualenv env_cython_sdist
@@ -185,9 +185,24 @@ jobs:
       - store_artifacts:
           path: ./dist
 
-      - run: *sdist-install-template
+      - run:
+          name: install sdist without cython
+          command: |
+            eval "$(pyenv init -)"
+            pyenv local $PYTHON
+            python -m virtualenv env_sdist
+            . env_sdist/bin/activate
+            pip install dist/dwave-neal-*.tar.gz
 
-      - run: *sdist-cython-install-template
+      - run:
+          name: install sdist with cython
+          command: |
+            eval "$(pyenv init -)"
+            pyenv local $PYTHON
+            python -m virtualenv env_cython_sdist
+            . env_cython_sdist/bin/activate
+            pip install cython
+            pip install dist/dwave-neal-*.tar.gz
 
   test-osx-3.7:
     <<: *osx-tests-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,11 @@ jobs:
       PYTHON: 3.8.0
       HOMEBREW_NO_AUTO_UPDATE: 1
 
+      # Force (lie about) macOS 10.9 binary compatibility.
+      # Needed for properly versioned wheels.
+      # See: https://github.com/MacPython/wiki/wiki/Spinning-wheels
+      MACOSX_DEPLOYMENT_TARGET: 10.9
+
     working_directory: ~/repo
 
     steps: 
@@ -188,30 +193,35 @@ jobs:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.7.4
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.6:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.6.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.5:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.5.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-3.4:
     <<: *osx-tests-template
     environment:
       PYTHON: 3.4.8
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   test-osx-2.7:
     <<: *osx-tests-template
     environment:
       PYTHON: 2.7.15
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 ##################################################################################################
@@ -278,6 +288,7 @@ jobs:
       xcode: "11.2.1"
     environment:
       PYTHON: 3.8.0
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
     working_directory: ~/repo
@@ -329,30 +340,35 @@ jobs:
     <<: *osx-build-template
     environment:
       PYTHON: 3.7.4
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.6:
     <<: *osx-build-template
     environment:
       PYTHON: 3.6.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.5:
     <<: *osx-build-template
     environment:
       PYTHON: 3.5.5
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-3.4:
     <<: *osx-build-template
     environment:
       PYTHON: 3.4.8
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
   build-osx-2.7:
     <<: *osx-build-template
     environment:
       PYTHON: 2.7.15
+      MACOSX_DEPLOYMENT_TARGET: 10.9
       HOMEBREW_NO_AUTO_UPDATE: 1
 
 workflows:


### PR DESCRIPTION
Otherwise wheels published for the latest macOS (10.15) will not be
available on older platforms.

Wheels are published for target returned from
`distutils.util.get_platform()`, which in turn uses macOS helper module,
`_osx_support`, `get_platform_osx()` function, which allows the target
to be overridden via *build-time* config variable
`MACOSX_DEPLOYMENT_TARGET` (needs to be set before Python's built).

For more about macOS binary wheels and targets, see
https://github.com/MacPython/wiki/wiki/Spinning-wheels.