### PR TITLE
Use latest dimod features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 cython==0.28.5
 
 numpy==1.18.1
-dimod==0.9.1
-six==1.12.0
+dimod==0.9.2
 
 mock
 

--- a/setup.py
+++ b/setup.py
@@ -64,9 +64,9 @@ if USE_CYTHON:
 
 packages = ['neal']
 
-install_requires = ['dimod>=0.7.7',
-                    'numpy>=1.14.0,<2.0.0',
-                    'six>=1.11.0,<2.0.0']
+install_requires = ['dimod>=0.9.2',
+                    'numpy>=1.16.0,<2.0.0',
+                    ]
 
 setup_requires = ['numpy>=1.14.0,<2.0.0']
 


### PR DESCRIPTION
Requires https://github.com/dwavesystems/dimod/pull/644

Note that this is a backwards compatibility breaking change:
* The previously deprecated `sweeps` parameter has been removed
* The previously deprecated `(samples, dict)` format for `initial_states` has been removed
* `seed` must now be provided as a 32-bit integer rather than 64

Also note that this uses `BQM.to_numpy_vectors` which is optimized on cyBQMs but still requires an intermediate copy. In principle this could all be done with dimod's internal c++ representation.