### PR TITLE
Update cookie methods in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -112,8 +112,8 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ['_static']
 
 def setup(app):
-   app.add_stylesheet('cookie_notice.css')
-   app.add_javascript('cookie_notice.js')
+   app.add_css_file('cookie_notice.css')
+   app.add_js_file('cookie_notice.js')
    app.add_config_value('target', 'repo', 'env')
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 # sphinx requirement for py34
 colorama<=0.4.1; sys_platform == "win32"
 
-sphinx
+sphinx>=4.0.0,<5.0.0
 sphinx_rtd_theme
 recommonmark


### PR DESCRIPTION
`app.add_stylesheet()` and `app.add_javascript()` were renamed in version 1.8 and obsoleted in version 4