### PR TITLE
Add cython to doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
-# sphinx requirement for py34
-colorama<=0.4.1; sys_platform == "win32"
-
 sphinx>=4.0.0,<5.0.0
 sphinx_rtd_theme
 recommonmark
+
+cython==0.29.21


### PR DESCRIPTION
Needed to build docs (unlike dimod, cython is not specified in setup.py). The docbuild for this repo is building successfully because it is incorrectly using the root requirements:
![image](https://user-images.githubusercontent.com/34041130/122075128-ad464800-cdae-11eb-8684-a10abc7261a7.png)
This means that it does not see doc-build requirements such as `sphinx>=4.0.0,<5.0.0` and in fact is building the docs using sphinx version 1.8.5. 
We might want to also pin docutils (as in https://github.com/dwavesystems/dwave-ocean-sdk/pull/133)  