### PR TITLE
Drop python 3.5 and remove support for numpy 1.21.0, 1.21.1

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,8 +6,6 @@ environment:
     secure: 9/YAQhmz9Kb1ZeXzhBYeQA==
 
   matrix:
-    - PYTHON: "C:\\Python35"
-    - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,7 +301,7 @@ workflows:
           name: build-manylinux1_<< matrix.architecture >>-py3<< matrix.python-minor >>
           matrix:
             parameters:
-              python-minor: [5, 6, 7, 8, 9]
+              python-minor: [6, 7, 8, 9]
               # We could build for 32bit as well, but since we don't have any
               # way to test it and it slows down compilation, we don't for
               # now.
@@ -323,7 +323,6 @@ workflows:
                 - 3.8-buster
                 - 3.7-stretch
                 - 3.6-jessie
-                - 3.5-jessie
             exclude:
               # numpy 1.16 does not support python 3.8+
               # dimod 0.9.2 does not support python 3.9+
@@ -349,7 +348,7 @@ workflows:
       - test-osx:
           matrix:
             parameters:
-              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]
       - test-doctest
 
   deploy:
@@ -363,7 +362,7 @@ workflows:
           name: build-manylinux1_<< matrix.architecture >>-py3<< matrix.python-minor >>
           matrix:
             parameters:
-              python-minor: [5, 6, 7, 8, 9]
+              python-minor: [6, 7, 8, 9]
               architecture: ["x86_64", "i686"]
       - build-sdist:
           filters:
@@ -388,4 +387,4 @@ workflows:
               ignore: /.*/
           matrix:
             parameters:
-              python-version: ["3.5.4", "3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,6 +342,10 @@ workflows:
               - numpy-version: ''
                 dimod-version: '==0.9.2'
                 image: 3.9-buster
+              # latest numpy (1.21.1) has a bug, remove this once 1.21.2 is released
+              - numpy-version: ''
+                dimod-version: ''
+                image: 3.7-stretch
       - test-osx:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,8 @@ jobs:
             python -m virtualenv env
             . env/bin/activate
             pip install -r tests/requirements.txt
-            pip install numpy'<< parameters.numpy-version >>' --upgrade
             pip install dimod'<< parameters.dimod-version >>' --upgrade
+            pip install numpy'<< parameters.numpy-version >>' --upgrade
             pip install dwave-neal --no-index -f dist/ --no-deps --force-reinstall
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
 
   test-linux:
     parameters:
-      image:
+      python-version:
         type: string
       numpy-version:
         type: string
@@ -90,7 +90,7 @@ jobs:
         type: string
 
     docker:
-      - image: circleci/python:<< parameters.image >>
+      - image: circleci/python:<< parameters.python-version >>
 
     steps:
       - checkout
@@ -308,7 +308,7 @@ workflows:
               architecture: ["x86_64"]
       - build-sdist
       - test-linux:
-          name: test-linux-<< matrix.image >>-dimod<< matrix.dimod-version >>-numpy<< matrix.numpy-version >>
+          name: test-linux-<< matrix.python-version >>-dimod<< matrix.dimod-version >>-numpy<< matrix.numpy-version >>
           # We could break each of these out into seperate jobs so that we
           # don't need to wait for the entire above matrix to complete, but
           # this is cleaner
@@ -318,33 +318,29 @@ workflows:
             parameters:
               numpy-version: [<1.19, <1.20, <1.21, <1.22]
               dimod-version: [==0.9.2, <0.11]
-              image:
-                - 3.9-buster
-                - 3.8-buster
-                - 3.7-stretch
-                - 3.6-jessie
+              python-version: &python-versions [3.6.8, 3.7.9, 3.8.9, 3.9.4]
             exclude:
               # dimod 0.9.2 does not support python 3.9+
               - numpy-version: <1.19
                 dimod-version: ==0.9.2
-                image: 3.9-buster
+                python-version: 3.9.4
               - numpy-version: <1.20
                 dimod-version: ==0.9.2
-                image: 3.9-buster
+                python-version: 3.9.4
               - numpy-version: <1.21
                 dimod-version: ==0.9.2
-                image: 3.9-buster
+                python-version: 3.9.4
               - numpy-version: <1.22
                 dimod-version: ==0.9.2
-                image: 3.9-buster
+                python-version: 3.9.4
               # latest numpy (1.21.1) has a bug, remove this once 1.21.2 is released
               - numpy-version: <1.22
                 dimod-version: <0.11
-                image: 3.7-stretch
+                python-version: 3.7.9
       - test-osx:
           matrix:
             parameters:
-              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: *python-versions
       - test-doctest
 
   deploy:
@@ -383,4 +379,4 @@ workflows:
               ignore: /.*/
           matrix:
             parameters:
-              python-version: ["3.6.8", "3.7.5", "3.8.6", "3.9.0"]
+              python-version: *python-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,34 +316,30 @@ workflows:
             - build-manylinux
           matrix:
             parameters:
-              numpy-version: ['==1.16.0', '']
-              dimod-version: ['==0.9.2', '']
+              numpy-version: [<1.19, <1.20, <1.21, <1.22]
+              dimod-version: [==0.9.2, <0.11]
               image:
                 - 3.9-buster
                 - 3.8-buster
                 - 3.7-stretch
                 - 3.6-jessie
             exclude:
-              # numpy 1.16 does not support python 3.8+
               # dimod 0.9.2 does not support python 3.9+
-              - numpy-version: '==1.16.0'
-                dimod-version: ''
+              - numpy-version: <1.19
+                dimod-version: ==0.9.2
                 image: 3.9-buster
-              - numpy-version: '==1.16.0'
-                dimod-version: ''
-                image: 3.8-buster
-              - numpy-version: '==1.16.0'
-                dimod-version: '==0.9.2'
+              - numpy-version: <1.20
+                dimod-version: ==0.9.2
                 image: 3.9-buster
-              - numpy-version: '==1.16.0'
-                dimod-version: '==0.9.2'
-                image: 3.8-buster
-              - numpy-version: ''
-                dimod-version: '==0.9.2'
+              - numpy-version: <1.21
+                dimod-version: ==0.9.2
+                image: 3.9-buster
+              - numpy-version: <1.22
+                dimod-version: ==0.9.2
                 image: 3.9-buster
               # latest numpy (1.21.1) has a bug, remove this once 1.21.2 is released
-              - numpy-version: ''
-                dimod-version: ''
+              - numpy-version: <1.22
+                dimod-version: <0.11
                 image: 3.7-stretch
       - test-osx:
           matrix:

--- a/neal/sampler.py
+++ b/neal/sampler.py
@@ -233,8 +233,7 @@ class SimulatedAnnealingSampler(dimod.Sampler, dimod.Initialized):
 
         # read out the BQM
         ldata, (irow, icol, qdata), off = bqm.to_numpy_vectors(
-            variable_order=variable_order,
-            dtype=np.double, index_dtype=np.intc)
+            variable_order=variable_order)
 
         if interrupt_function and not callable(interrupt_function):
             raise TypeError("'interrupt_function' should be a callable")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 numpy==1.19.4; python_version >= '3.6'
-numpy==1.18.5; python_version == '3.5'
 cython==0.29.21
 dimod==0.9.11

--- a/setup.py
+++ b/setup.py
@@ -65,10 +65,10 @@ if USE_CYTHON:
 packages = ['neal']
 
 install_requires = ['dimod>=0.9.2',
-                    'numpy>=1.16.0',
+                    'numpy>=1.16.0,<2.0.0,!=1.21.0,!=1.21.1',
                     ]
 
-setup_requires = ['numpy>=1.16.0']
+setup_requires = ['numpy>=1.16.0,<2.0.0,!=1.21.0,!=1.21.1']
 
 classifiers = [
     'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -74,14 +74,13 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
 ]
 
-python_requires = '>=3.5'
+python_requires = '>=3.6'
 
 # add __version__, __author__, __authoremail__, __description__ to this namespace
 exec(open("./neal/package_info.py").read())


### PR DESCRIPTION
- drop python 3.5 testing in CircleCI
- remove support for numpy 1.21.0 and 1.21.1 (bug explained [here](https://github.com/dwavesystems/dimod/issues/901))
- remove deprecated args (from dimod 0.10)
- to do in a later pr: modernize build